### PR TITLE
Perform a None -> null conversion in JLineConsole.setStartupHook()

### DIFF
--- a/src/org/python/util/JLineConsole.java
+++ b/src/org/python/util/JLineConsole.java
@@ -23,6 +23,7 @@ import jnr.constants.platform.Errno;
 
 import org.python.core.PlainConsole;
 import org.python.core.PyObject;
+import org.python.core.Py;
 
 /**
  * This class uses <a href="http://jline.sourceforge.net/">JLine</a> to provide readline like
@@ -288,6 +289,10 @@ public class JLineConsole extends PlainConsole {
      * Sets the startup hook (called prior to each readline)
      */
     public void setStartupHook(PyObject hook) {
+        // Convert None to null here, so that readerReadLine can use only a null check
+        if (hook == Py.None) {
+            hook = null;
+        }
         startup_hook = hook;
     }
 }


### PR DESCRIPTION
JLineConsole.readerReadLine() checks if startupHook is null before invoking __call__(). If startupHook is None rather than null, the invocation will proceed, resulting in a TypeError.

This fix converts None to null in JLineConsole.setStartupHook() allowing the null-check in readerReadLine() to be sufficient. Put the check in setStartupHook since it is likely to be called less often.

This fix allows the basic IPython console to work on Jython, with the following Jython specific modifications:

[https://github.com/Brittix1023/ipython/tree/basic-jython-fixes](https://github.com/Brittix1023/ipython/tree/basic-jython-fixes)

