### PR TITLE
Implement Popen.pid (http://bugs.jython.org/issue2221)

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1366,7 +1366,7 @@ class Popen(object):
             else:
                 return field
 
-        if os._name != 'nt':
+        if os._name not in _win_oses:
 
             def _get_pid(self, pid_field='pid'):
                 field = self._get_private_field(self._process, pid_field)

--- a/Lib/test/test_subprocess_jy.py
+++ b/Lib/test/test_subprocess_jy.py
@@ -5,6 +5,23 @@ import sys
 from test import test_support
 from subprocess import PIPE, Popen, _cmdline2list
 
+
+class PidTest(unittest.TestCase):
+
+    def testPid(self):
+        # Cannot use sys.executable here because it's a script and has different
+        # pid than the actual started Java process.
+        p = Popen(['python', '-c', 'import os; print os.getpid()'],
+                  stdout=PIPE)
+        p.wait()
+        self.assertEquals(int(p.stdout.read()), p.pid)
+
+    def testNonExistingField(self):
+        # Test we don't crash if Process class doesn't have field we need.
+        p = Popen(['echo foo'], shell=True, stdout=PIPE)
+        self.assertIsNone(p._get_pid('nonex'))
+
+
 class EnvironmentInheritanceTest(unittest.TestCase):
 
     def testDefaultEnvIsInherited(self):
@@ -70,6 +87,7 @@ class Cmdline2ListTestCase(unittest.TestCase):
 
 def test_main():
     test_support.run_unittest(
+        PidTest,
         EnvironmentInheritanceTest,
         JythonOptsTest,
         Cmdline2ListTestCase)


### PR DESCRIPTION
This code has been tested on Linux and Windows 7, and same approach was
tested earlier also on OSX.

If underlying Process implementation is not what we expect (i.e. doesn't
have 'pid' or 'handle' field, depending on OS), pid will be None. This
functionality is tested by querying a non-existing field.

Pid would also be None if a security manager would restricts reading
aforementioned private fields. In practice execution stops already in
'_setup_env' under such security manager, though.