### PR TITLE
Restore get_line_buffer method in readline.py

### DIFF
--- a/Lib/readline.py
+++ b/Lib/readline.py
@@ -58,6 +58,9 @@ _setup_history()
 def parse_and_bind(string):
     pass
 
+def get_line_buffer():
+    return str(_reader.cursorBuffer.buffer)
+
 def insert_text(string):
     _reader.putString(string)
 


### PR DESCRIPTION
Seems to have been removed with commit 56eb138d330762d25ceabffd1ee04342b186f071