### PR TITLE
PyUnicode cannot be serialized

### DIFF
--- a/Lib/test/test_java_integration.py
+++ b/Lib/test/test_java_integration.py
@@ -644,6 +644,10 @@ class SerializationTest(unittest.TestCase):
         date_list = [Date(), Date()]
         self.assertEqual(date_list, roundtrip_serialization(date_list))
 
+    def test_java_serialization_unicode(self):
+            str = "test_str"
+            self.assertEqual(str, roundtrip_serialization(str))
+
     def test_java_serialization_pycode(self):
 
         def universal_answer():

--- a/src/org/python/core/PyUnicode.java
+++ b/src/org/python/core/PyUnicode.java
@@ -1,5 +1,6 @@
 package org.python.core;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -140,7 +141,7 @@ public class PyUnicode extends PyString implements Iterable {
      * Index translation between code point index (as seen by Python) and UTF-16 index (as used in
      * the Java String.
      */
-    private interface IndexTranslator extends Serializable{
+    private interface IndexTranslator extends Serializable {
 
         /** Number of supplementary characters (hence point code length may be found). */
         public int suppCount();


### PR DESCRIPTION
since beta 4 PyUnicode cannot be serialized because IndexTranslator was added and IndexTranslator doens't implement serialiazble.