### PR TITLE
Set direct mode if sys.exectuable is None or empty for standalone installations

### DIFF
--- a/Lib/distutils/command/build.py
+++ b/Lib/distutils/command/build.py
@@ -114,7 +114,7 @@ class build(Command):
             self.build_scripts = os.path.join(self.build_base,
                                               'scripts-' + sys.version[0:3])
 
-        if self.executable is None:
+        if self.executable is None and sys.executable:  # sys.executable is None for standalone jar installs...be careful
             self.executable = os.path.normpath(sys.executable)
 
     def run(self):

--- a/Lib/distutils/tests/test_build_py.py
+++ b/Lib/distutils/tests/test_build_py.py
@@ -5,6 +5,7 @@ import sys
 import StringIO
 import unittest
 
+from distutils.command.build import build
 from distutils.command.build_py import build_py
 from distutils.core import Distribution
 from distutils.errors import DistutilsFileError
@@ -108,6 +109,22 @@ class BuildPyTestCase(support.TempdirManager,
             sys.dont_write_bytecode = old_dont_write_bytecode
 
         self.assertTrue('byte-compiling is disabled' in self.logs[0][1])
+
+    def test_self_executable_cond_set(self):
+        # Make sure self.executable is only set when not using a standalone jar
+        pkg_dir, dist = self.create_dist()
+        cmd = build(dist)
+        cmd.initialize_options()
+        old_exe = sys.executable
+        sys.executable = None
+        cmd.finalize_options()
+        self.assertEqual(cmd.executable, None)
+
+        sys.executable = "/fake/path"
+        cmd.finalize_options()
+        self.assertEqual(cmd.executable, "/fake/path")
+
+        sys.executable = old_exe
 
 def test_suite():
     return unittest.makeSuite(BuildPyTestCase)

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -465,15 +465,15 @@ def byte_compile (py_files,
     # First, if the caller didn't force us into direct or indirect mode,
     # figure out which mode we should be in.  We take a conservative
     # approach: choose direct mode *only* if the current interpreter is
-    # in debug mode and optimize is 0.  If we're not in debug mode (-O
-    # or -OO), we don't know which level of optimization this
-    # interpreter is running with, so we can't do direct
+    # in standalone mode (sys.executable is None) or debug mode and optimize is 0.
+    # If we're not in debug mode (-O or -OO), we don't know which level of
+    # optimization this interpreter is running with, so we can't do direct
     # byte-compilation and be certain that it's the right thing.  Thus,
     # always compile indirectly if the current interpreter is in either
     # optimize mode, or if either optimization level was requested by
     # the caller.
     if direct is None:
-        direct = (__debug__ and optimize == 0)
+        direct = not sys.executable or (__debug__ and optimize == 0)
 
     # "Indirect" byte-compilation: write a temporary script and then
     # run it with the appropriate flags.


### PR DESCRIPTION
Otherwise, calls to setup() will eventually fail because sys.exectuable is None and the temporary script generated in byte_compile will fail.

Also, in the commands/build.py, there is also an assumption that sys.executable will never be None, which leads to ```os.path.normpath(sys.executable)``` causing string errors. Looks like this bug was introduced in: https://mail.python.org/pipermail/jython-checkins/2015-September/001547.html