### PR TITLE
Wait should always joins the coupler threads

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1426,13 +1426,13 @@ class Popen(object):
             attribute."""
             if self.returncode is None:
                 self.returncode = self._process.waitFor()
-                for coupler in (self._stdout_thread, self._stderr_thread):
-                    if coupler:
-                        coupler.join()
-                if self._stdin_thread:
-                    # The stdin thread may be blocked forever, forcibly
-                    # stop it
-                    self._stdin_thread.interrupt()
+            for coupler in (self._stdout_thread, self._stderr_thread):
+                if coupler:
+                    coupler.join()
+            if self._stdin_thread:
+                # The stdin thread may be blocked forever, forcibly
+                # stop it
+                self._stdin_thread.interrupt()
             return self.returncode
 
         def terminate(self):


### PR DESCRIPTION
If a caller is using poll(), and the poll() sets returncode != None, then a subsequent call to wait() will never join the coupler threads.
In the case that the execution context is redirecting output to files (e.g. if the process is expected to generate large amounts of output), the coupler threads may not yet be complete.
At that point, the caller cannot be certain that the output buffers are flushed (the implication being that the caller owns the I/O streams, but has no way to tell when they are flushed - the process may no longer be running, but only wait() will currently join the couplers).
