### PR TITLE
Make the calendar used by the time module be Gregorian all the way to match CPython's implementation

### DIFF
--- a/src/org/python/modules/time/Time.java
+++ b/src/org/python/modules/time/Time.java
@@ -226,12 +226,15 @@ public class Time implements ClassDictInit
     }
 
     private static GregorianCalendar _tupletocal(PyTuple tup) {
-        return new GregorianCalendar(item(tup, 0),
-                                     item(tup, 1),
-                                     item(tup, 2),
-                                     item(tup, 3),
-                                     item(tup, 4),
-                                     item(tup, 5));
+        GregorianCalendar gc = new GregorianCalendar(item(tup, 0),
+                                                     item(tup, 1),
+                                                     item(tup, 2),
+                                                     item(tup, 3),
+                                                     item(tup, 4),
+                                                     item(tup, 5));
+                                                     
+        gc.setGregorianChange(new Date(Long.MIN_VALUE));
+        return gc;
     }
 
     public static double mktime(PyTuple tup) {
@@ -254,6 +257,8 @@ public class Time implements ClassDictInit
     protected static PyTimeTuple _timefields(double secs, TimeZone tz) {
         GregorianCalendar cal = new GregorianCalendar(tz);
         cal.clear();
+        cal.setGregorianChange(new Date(Long.MIN_VALUE));
+
         secs = secs * 1000;
         if (secs < Long.MIN_VALUE || secs > Long.MAX_VALUE) {
             throw Py.ValueError("timestamp out of range for platform time_t");


### PR DESCRIPTION
Before the patch:
>>> time.gmtime(-12212553600)
time.struct_time(tm_year=1583, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=0, tm_sec=0, tm_wday=5, tm_yday=1, tm_isdst=0)
>>> time.gmtime(-12212553601)
time.struct_time(tm_year=1582, tm_mon=12, tm_mday=31, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=4, tm_yday=355, tm_isdst=0)
>>>

After the patch it matches Python 2.7, Python 3.6 and PyPy:
>>> time.gmtime(-12212553600)
time.struct_time(tm_year=1583, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=0, tm_sec=0, tm_wday=5, tm_yday=1, tm_isdst=0)
>>> time.gmtime(-12212553601)
time.struct_time(tm_year=1582, tm_mon=12, tm_mday=31, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=4, tm_yday=365, tm_isdst=0)
>>>
