### PR TITLE
A series of patches to allow jython to work with msgpack without

### DIFF
--- a/src/org/python/core/Py2kBuffer.java
+++ b/src/org/python/core/Py2kBuffer.java
@@ -185,28 +185,33 @@ public class Py2kBuffer extends PySequence implements BufferProtocol {
     }
 
     @Override
-    public PyString __repr__() {
+    public PyString __repr__(){
+        return buffer___repr__();
+    }
+
+    @ExposedMethod(doc=BuiltinDocs.buffer___repr___doc)
+    public PyString buffer___repr__() {
         String fmt = "<read-only buffer for %s, size %d, offset %d at 0x%s>";
         String ret = String.format(fmt, Py.idstr((PyObject)object), size, offset, Py.idstr(this));
         return new PyString(ret);
     }
 
-    @Override
-    public PyString __str__() {
+    public String toString(){
         PyBuffer buf = getBuffer();
         try {
             if (buf instanceof BaseBuffer) {
                 // In practice, it always is
-                return new PyString(buf.toString());
+                return buf.toString();
             } else {
                 // But just in case ...
                 String s = StringUtil.fromBytes(buf);
-                return new PyString(s);
+                return s ;
             }
         } finally {
             buf.release();
         }
     }
+
 
     /**
      * {@inheritDoc} A <code>buffer</code> implements this as concatenation and returns a

--- a/src/org/python/core/PyByteArray.java
+++ b/src/org/python/core/PyByteArray.java
@@ -1325,8 +1325,10 @@ public class PyByteArray extends BaseBytes implements BufferProtocol {
         } else if (oType == PyString.TYPE) {
             // Will fail if somehow not 8-bit clean
             setslice(size, size, 1, (PyString)o);
+        } else if (o instanceof PyMemoryView){
+            setslice(size, size, 1, (BufferProtocol)o);
         } else {
-            // Unsuitable type
+	    // Unsuitable type
             throw ConcatenationTypeError(oType, TYPE);
         }
         return this;
@@ -1996,12 +1998,17 @@ public class PyByteArray extends BaseBytes implements BufferProtocol {
      */
     @Override
     public String toString() {
-        return bytearray_repr();
+        return this.asString();
+    }
+
+    @Override
+    public PyString __repr__(){
+       return bytearray___repr__();
     }
 
     @ExposedMethod(names = {"__repr__"}, doc = BuiltinDocs.bytearray___repr___doc)
-    final synchronized String bytearray_repr() {
-        return basebytes_repr("bytearray(b", ")");
+    final synchronized PyString bytearray___repr__() {
+        return new PyString(basebytes_repr("bytearray(b", ")"));
     }
 
     /**

--- a/src/org/python/core/PyMemoryView.java
+++ b/src/org/python/core/PyMemoryView.java
@@ -67,7 +67,8 @@ public class PyMemoryView extends PySequence implements BufferProtocol, Traverse
         ArgParser ap = new ArgParser("memoryview", args, keywords, "object");
         PyObject obj = ap.getPyObject(0);
 
-        if (obj instanceof BufferProtocol) {
+        // memoryview in 2.7 throws typeerror on unicode rather than assuming encoding like buffer().
+        if (obj instanceof PyString && !(obj instanceof PyUnicode)) {
             return new PyMemoryView((BufferProtocol)obj);
         } else {
             throw Py.TypeError("cannot make memory view because object does not have "

--- a/src/org/python/modules/struct.java
+++ b/src/org/python/modules/struct.java
@@ -7,7 +7,6 @@
  */
 
 package org.python.modules;
-
 import org.python.core.Py;
 import org.python.core.PyException;
 import org.python.core.PyFloat;
@@ -21,6 +20,8 @@ import org.python.core.PyTuple;
 import java.math.BigInteger;
 import org.python.core.ClassDictInit;
 import org.python.core.PyArray;
+import org.python.core.PyByteArray;
+import org.python.core.Py2kBuffer;
 
 /**
  * This module performs conversions between Python values and C
@@ -1077,7 +1078,7 @@ public class struct implements ClassDictInit {
      * The string must contain exactly the amount of data required by
      * the format (i.e. len(string) must equal calcsize(fmt)).
      */
-   
+
     public static PyTuple unpack(String format, String string) {
         FormatDef[] f = whichtable(format);
         int size = calcsize(format, f);
@@ -1096,11 +1097,36 @@ public class struct implements ClassDictInit {
             throw StructError("unpack str size does not match format");
          return unpack(f, size, format, new ByteStream(string));
     }
-    
-    public static PyTuple unpack_from(String format, String string) {
-        return unpack_from(format, string, 0);   
+
+    public static PyTuple unpack(String format, Py2kBuffer buffer){
+        return unpack(format, buffer.toString());
     }
-        
+
+    public static PyTuple unpack(String format, PyByteArray bytearray) {
+        /* bytearray is added in 2.7.7 */
+        return unpack(format, bytearray.toString());
+    }
+
+    public static PyTuple unpack_from(String format, Py2kBuffer buffer) {
+        return unpack_from(format, buffer.toString(), 0);
+    }
+
+    public static PyTuple unpack_from(String format, PyByteArray bytearray) {
+        return unpack_from(format, bytearray.toString(), 0);
+    }
+
+    public static PyTuple unpack_from(String format, Py2kBuffer buffer, int offset) {
+        return unpack_from(format, buffer.toString(), offset);
+    }
+
+    public static PyTuple unpack_from(String format, PyByteArray bytearray, int offset) {
+        return unpack_from(format, bytearray.toString(), offset);
+    }
+
+    public static PyTuple unpack_from(String format, String string) {
+        return unpack_from(format, string, 0);
+    }
+
     public static PyTuple unpack_from(String format, String string, int offset) {
         FormatDef[] f = whichtable(format);
         int size = calcsize(format, f);
@@ -1109,7 +1135,7 @@ public class struct implements ClassDictInit {
             throw StructError("unpack_from str size does not match format");
         return unpack(f, size, format, new ByteStream(string, offset));
     }
-    
+
     static PyTuple unpack(FormatDef[] f, int size, String format, ByteStream str) {
         PyList res = new PyList();
         int flen = format.length();
@@ -1137,7 +1163,6 @@ public class struct implements ClassDictInit {
         }
         return PyTuple.fromIterable(res);
     }
-
 
     static PyException StructError(String explanation) {
         return new PyException(error, explanation);


### PR DESCRIPTION
workarounds in upstream msgpack. This also allows pip-18.1
compatitiblity by way of dependency when combined with the Lib/zlib.py
GZIP_TRAILER fix in decompress.

* src/org/python/core/Py2kBuffer.java

This is fairly cosmetic in that it moves __str__() functionality to
toString() and fixes the intended __repr__() customization that matches
cython and was broken in the 11 year old __repr__() derived object
recursion overflow workaround.

* src/org/python/core/PyMemoryView.java

This actually restricts and removes problematic functionality to make it
behave like cython which rejects attempts to take a memoryview of a
unicode object with a TypeError exception.  This is important for
pip/msgpack compatibility due to the fact that TypeError triggers use of
buffer to wrap the bytes in utf-16-be encoding rather than attempting to
strip it off entirely and potentially throw a unicode decode error.

* src/org/python/core/PyByteArray.java

This allows bytearray objects to __iadd__ PyMemoryView objects.
b=bytearray('asdf')
b+=memoryview('jkl;')

This is used by msgpack and supported by cython.

This also switches toString to create a string appropriate for java and
moves __repr__ functionality into bytearray___repr for cleaner repr
support and using the (String) value in struct.unpack methods.

* src/org/python/modules/struct.java

This set of changes allows struct to unpack from Py2kBuffer aka buffer
which is support by cython 2.7.x and used as a workaround for cython <=
2.7.6 which does not support unpacking from a bytearray.

It also adds support for unpacking from a bytearray to provide
compatibility without the workaround in msgpack.