### PR TITLE
memoryview should reject unicode input with TypeError

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -873,6 +873,15 @@ class BaseTest(unittest.TestCase):
             a[1:-1] = array.array(self.typecode, self.example[1-n:-1])
 
         v = memoryview(a)
+
+        # PyMemoryView still currently accepts all inbound array types but can be
+        # made more restrictive via accept_array_types in PyMemoryView Py2kBuffer
+        # is less restrictive and assumes UTF-16BE encoding for codepoints > 255.
+        #
+        # try:
+        #     v = memoryview(a)
+        # except TypeError, e:
+        #     v = buffer(a)
         orig = a[:]
 
         self.assertRaises(BufferError, resize, -1)

--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -427,6 +427,15 @@ class BytesMemoryviewTest(unittest.TestCase,
             self.assertRaises(TypeError, memoryview, argument=ob)
             self.assertRaises(TypeError, memoryview, ob, argument=True)
 
+    def test_unicode_resistance(self):
+        """Py 2.x doesn't support memoryview from Unicode unlike buffer which
+        " translates to UTF-32BE. The error is a feature that forces explicit
+        " decode, and is used in msgpack / pip to trigger appropriate decode.
+        """
+        self.assertRaises(TypeError, memoryview, u'asdf')
+
+
+
 #class ArrayMemoryviewTest(unittest.TestCase,
     #BaseMemoryviewTests, BaseArrayMemoryTests):
 
@@ -442,6 +451,7 @@ class BytesMemoryviewTest(unittest.TestCase,
 class BytesMemorySliceTest(unittest.TestCase,
     BaseMemorySliceTests, BaseBytesMemoryTests):
     pass
+
 
 #class ArrayMemorySliceTest(unittest.TestCase,
     #BaseMemorySliceTests, BaseArrayMemoryTests):


### PR DESCRIPTION
Memoryview in py2.7 raises TypeError on unicode input whereas in jython, it strips Unicode encoding entirely. The older buffer interface encodes unicode as utf-16be.

Downstream code in pip, msgpack, and likely other places, catch TypeError and adjust for the Unicode input.

I'm not sure what the used case is for other array types that py2.7/memoryview doesn't support being supported by jython, but it seems like something that may have been added because the design allowed it.  These are not likely to typecast into something usable in downstream code and may also be more of a liability than a feature.  

Since I did not find cases where these cause breakage, and don't know who might be using memoryview of the other array types, I added code that would allow targeted removal of specific array types by removing the typecode from `accept_array_types = "zcbBhHiIlLduf"`.  There is also a commented out try catch block in the test_array.py code that would fix tests attempting to create a memoryview of the other types. Currently it includes all types so it has no effect other than blocking automatic addition of any new array types to the permitted list, and pointing the way to a quick fix if we discover this causes downstream issues like the Unicode memoryview does.