### PR TITLE
Bytearray iadd

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -694,6 +694,8 @@ class ByteArrayTest(BaseBytesTest):
         self.assertTrue(b is b1)
         b += b"xyz"
         self.assertEqual(b, b"abcdefxyz")
+        b += memoryview('zyx') # Used by pip / msgpack
+        self.assertEqual(b, b"abcdefxyzzyx")
         try:
             b += u""
         except TypeError:

--- a/src/org/python/core/PyByteArray.java
+++ b/src/org/python/core/PyByteArray.java
@@ -1325,8 +1325,10 @@ public class PyByteArray extends BaseBytes implements BufferProtocol {
         } else if (oType == PyString.TYPE) {
             // Will fail if somehow not 8-bit clean
             setslice(size, size, 1, (PyString)o);
+        } else if (o instanceof PyMemoryView){
+            setslice(size, size, 1, (BufferProtocol)o);
         } else {
-            // Unsuitable type
+	    // Unsuitable type
             throw ConcatenationTypeError(oType, TYPE);
         }
         return this;

--- a/src/org/python/core/PyByteArray.java
+++ b/src/org/python/core/PyByteArray.java
@@ -1328,7 +1328,7 @@ public class PyByteArray extends BaseBytes implements BufferProtocol {
         } else if (o instanceof PyMemoryView){
             setslice(size, size, 1, (BufferProtocol)o);
         } else {
-	    // Unsuitable type
+            // Unsuitable type
             throw ConcatenationTypeError(oType, TYPE);
         }
         return this;


### PR DESCRIPTION
msgpack/fallback.py which newer pip depends on uses `bytearray += <type memorview>` which is supported by py2.x.

Note that it does not support += of the older <type buffer> most likely due to the fact that buffer can contain encoded Unicode whereas memoryview should throw a TypeError and force explicit encoding.  The typeerror is covered in a separate test/patch/pull-request.