### PR TITLE
Allow unpack and unpack_from bytearray and <type buffer>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ notifications:
 install:
   - ant
 
-language: java
-
 os:
   - linux
   - osx
+  - windows
+
+language: java
+ 
+dist: percise
 
 env:
   matrix:
@@ -27,6 +30,12 @@ matrix:
      - os: osx
        env: CUSTOM_JDK="openjdk7"
      - os: osx
+       env: CUSTOM_JDK="oraclejdk8"
+     - os: windows
+       env: CUSTOM_JDK="oraclejdk7"
+     - os: windows
+       env: CUSTOM_JDK="openjdk7"
+     - os: windows
        env: CUSTOM_JDK="oraclejdk8"
      # On Linux, run with specific JDKs only.
      - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,23 @@ os:
   - linux
   - osx
 
+language:
+  - java
+
 env:
   matrix:
     - CUSTOM_JDK="default"
     - CUSTOM_JDK="oraclejdk7"
     - CUSTOM_JDK="openjdk7"
     - CUSTOM_JDK="oraclejdk8"
+    - CUSTOM_JDK="openjdk8"
+
+
+jdk:
+    - oraclejdk7
+    - oraclejdk8
+    - openjdk8
+    - openjdk7
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,26 @@ install: ant
 os:
   - linux
   - osx
-
-
-env:
-  matrix:
-    - CUSTOM_JDK="default"
-    - CUSTOM_JDK="oraclejdk7"
-    - CUSTOM_JDK="openjdk7"
-    - CUSTOM_JDK="oraclejdk8"
-    - CUSTOM_JDK="openjdk8"
+ 
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7 
+  - default
 
 
 matrix:
-  exclude:
+  include:
      # On OSX, run with default JDK only.
      - os: osx
-       env: CUSTOM_JDK="oraclejdk7"
-     - os: osx
-       env: CUSTOM_JDK="openjdk7"
-     - os: osx
-       env: CUSTOM_JDK="oraclejdk8"
+       jdk: default
      # On Linux, run with specific JDKs only.
      - os: linux
-       env: CUSTOM_JDK="default"
+       jdk: oraclejdk8
+     - os: linux
+       jdk: openjdk7
+     - os: linux
+       jdk: oraclejdk7
 
 before_install:
   # Patch for buffer overflow bug, see https://github.com/travis-ci/travis-ci/issues/5227
@@ -42,10 +39,6 @@ before_install:
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - hostname
   - cat /etc/hosts # optionally check the content *after*
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install ant; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
-
+  
 script: ant && ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ os:
   - linux
   - osx
 
-language:
-  - java
 
 env:
   matrix:
@@ -22,12 +20,6 @@ env:
     - CUSTOM_JDK="oraclejdk8"
     - CUSTOM_JDK="openjdk8"
 
-
-jdk:
-    - oraclejdk7
-    - oraclejdk8
-    - openjdk8
-    - openjdk7
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,36 @@
-language: java
-
 notifications:
   email:
     recipients:
-      - jython-dev@lists.sourceforge.net
+      - ray.ferguson@devendortech.com
 
-install: ant
+install:
+  - ant
+  - oraclejdk7
+  - openjdk7
 
 os:
   - linux
   - osx
- 
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7 
-  - default
 
+env:
+  matrix:
+    - CUSTOM_JDK="default"
+    - CUSTOM_JDK="oraclejdk7"
+    - CUSTOM_JDK="openjdk7"
+    - CUSTOM_JDK="oraclejdk8"
 
 matrix:
-  include:
+  exclude:
      # On OSX, run with default JDK only.
      - os: osx
-       jdk: default
+       env: CUSTOM_JDK="oraclejdk7"
+     - os: osx
+       env: CUSTOM_JDK="openjdk7"
+     - os: osx
+       env: CUSTOM_JDK="oraclejdk8"
      # On Linux, run with specific JDKs only.
      - os: linux
-       jdk: oraclejdk8
-     - os: linux
-       jdk: openjdk7
-     - os: linux
-       jdk: oraclejdk7
+       env: CUSTOM_JDK="default"
 
 before_install:
   # Patch for buffer overflow bug, see https://github.com/travis-ci/travis-ci/issues/5227
@@ -39,6 +40,10 @@ before_install:
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - hostname
   - cat /etc/hosts # optionally check the content *after*
-  
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install ant; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
+
 script: ant && ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
 
 install:
   - ant
-  - oraclejdk7
-  - openjdk7
+
+language: java
 
 os:
   - linux

--- a/Lib/test/test_struct_jy.py
+++ b/Lib/test/test_struct_jy.py
@@ -1,0 +1,158 @@
+import unittest
+from test import test_support
+import struct
+
+import sys
+ISBIGENDIAN = sys.byteorder == "big"
+
+class StructTests(unittest.TestCase): # (format, argument, big-endian result, little-endian result, asymmetric)
+    _tests = [
+        ('c', 'a', 'a', 'a', 0),
+        ('xc', 'a', '\0a', '\0a', 0),
+        ('cx', 'a', 'a\0', 'a\0', 0),
+        ('s', 'a', 'a', 'a', 0),
+        ('0s', 'helloworld', '', '', 1),
+        ('1s', 'helloworld', 'h', 'h', 1),
+        ('9s', 'helloworld', 'helloworl', 'helloworl', 1),
+        ('10s', 'helloworld', 'helloworld', 'helloworld', 0),
+        ('11s', 'helloworld', 'helloworld\0', 'helloworld\0', 1),
+        ('20s', 'helloworld', 'helloworld'+10*'\0', 'helloworld'+10*'\0', 1),
+        ('b', 7, '\7', '\7', 0),
+        ('b', -7, '\371', '\371', 0),
+        ('B', 7, '\7', '\7', 0),
+        ('B', 249, '\371', '\371', 0),
+        ('h', 700, '\002\274', '\274\002', 0),
+        ('h', -700, '\375D', 'D\375', 0),
+        ('H', 700, '\002\274', '\274\002', 0),
+        ('H', 0x10000-700, '\375D', 'D\375', 0),
+        ('i', 70000000, '\004,\035\200', '\200\035,\004', 0),
+        ('i', -70000000, '\373\323\342\200', '\200\342\323\373', 0),
+        ('I', 70000000L, '\004,\035\200', '\200\035,\004', 0),
+        ('I', 0x100000000L-70000000, '\373\323\342\200', '\200\342\323\373', 0),
+        ('l', 70000000, '\004,\035\200', '\200\035,\004', 0),
+        ('l', -70000000, '\373\323\342\200', '\200\342\323\373', 0),
+        ('L', 70000000L, '\004,\035\200', '\200\035,\004', 0),
+        ('L', 0x100000000L-70000000, '\373\323\342\200', '\200\342\323\373', 0),
+        ('f', 2.0, '@\000\000\000', '\000\000\000@', 0),
+        ('d', 2.0, '@\000\000\000\000\000\000\000',
+                   '\000\000\000\000\000\000\000@', 0),
+        ('f', -2.0, '\300\000\000\000', '\000\000\000\300', 0),
+        ('d', -2.0, '\300\000\000\000\000\000\000\000',
+                   '\000\000\000\000\000\000\000\300', 0),
+    ]
+
+    def test_struct(self):
+        for fmt, arg, big, lil, asy in self._tests:
+            for (xfmt, exp) in [('>'+fmt, big), ('!'+fmt, big), ('<'+fmt, lil),
+                                ('='+fmt, ISBIGENDIAN and big or lil)]:
+                res = struct.pack(xfmt, arg)
+                self.assertEqual(res,exp,msg="pack(%r, %r) -> %r # expected %r" %
+                                             (fmt, arg, res, exp))
+                n=struct.calcsize(xfmt)
+                self.assertEqual(n, len(res),msg="calcsize(%r) -> %d # expected %d" %
+                                                                      (xfmt, n, len(res)))
+                rev = struct.unpack(xfmt, res)[0]
+                if asy:
+                    self.assertNotEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                    (fmt, res, rev, exp))
+                else:
+                    self.assertEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                 (fmt, res, rev, arg))
+
+    def test_struct_unpack_bytearray(self):
+        for fmt, arg, big, lil, asy in self._tests:
+            for (xfmt, exp) in [('>'+fmt, big), ('!'+fmt, big), ('<'+fmt, lil),
+                                ('='+fmt, ISBIGENDIAN and big or lil)]:
+                res = struct.pack(xfmt, arg)
+                self.assertEqual(res,exp,msg="pack(%r, %r) -> %r # expected %r" %
+                                             (fmt, arg, res, exp))
+                n=struct.calcsize(xfmt)
+                self.assertEqual(n, len(res),msg="calcsize(%r) -> %d # expected %d" %
+                                                                      (xfmt, n, len(res)))
+                rev = struct.unpack(xfmt, bytearray(res))[0]
+                if asy:
+                    self.assertNotEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                    (fmt, res, rev, exp))
+                else:
+                    self.assertEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                 (fmt, res, rev, arg))
+
+    def test_struct_unpack_buffer(self):
+        for fmt, arg, big, lil, asy in self._tests:
+            for (xfmt, exp) in [('>'+fmt, big), ('!'+fmt, big), ('<'+fmt, lil),
+                                ('='+fmt, ISBIGENDIAN and big or lil)]:
+                res = struct.pack(xfmt, arg)
+                self.assertEqual(res,exp,msg="pack(%r, %r) -> %r # expected %r" %
+                                             (fmt, arg, res, exp))
+                n=struct.calcsize(xfmt)
+                self.assertEqual(n, len(res),msg="calcsize(%r) -> %d # expected %d" %
+                                                                      (xfmt, n, len(res)))
+                rev = struct.unpack(xfmt, buffer(res))[0]
+                if asy:
+                    self.assertNotEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                    (fmt, res, rev, exp))
+                else:
+                    self.assertEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                 (fmt, res, rev, arg))
+    def test_struct_unpack_from(self):
+        for fmt, arg, big, lil, asy in self._tests:
+            for (xfmt, exp) in [('>'+fmt, big), ('!'+fmt, big), ('<'+fmt, lil),
+                                ('='+fmt, ISBIGENDIAN and big or lil)]:
+                res = struct.pack(xfmt, arg)
+                self.assertEqual(res,exp,msg="pack(%r, %r) -> %r # expected %r" %
+                                             (fmt, arg, res, exp))
+                n=struct.calcsize(xfmt)
+                self.assertEqual(n, len(res),msg="calcsize(%r) -> %d # expected %d" %
+                                                                      (xfmt, n, len(res)))
+                rev = struct.unpack_from(xfmt, res)[0]
+                if asy:
+                    self.assertNotEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                    (fmt, res, rev, exp))
+                else:
+                    self.assertEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                 (fmt, res, rev, arg))
+
+    def test_struct_unpack_from_bytearray(self):
+        for fmt, arg, big, lil, asy in self._tests:
+            for (xfmt, exp) in [('>'+fmt, big), ('!'+fmt, big), ('<'+fmt, lil),
+                                ('='+fmt, ISBIGENDIAN and big or lil)]:
+                res = struct.pack(xfmt, arg)
+                self.assertEqual(res,exp,msg="pack(%r, %r) -> %r # expected %r" %
+                                             (fmt, arg, res, exp))
+                n=struct.calcsize(xfmt)
+                self.assertEqual(n, len(res),msg="calcsize(%r) -> %d # expected %d" %
+                                                                      (xfmt, n, len(res)))
+                rev = struct.unpack_from(xfmt, bytearray(res))[0]
+                if asy:
+                    self.assertNotEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                    (fmt, res, rev, exp))
+                else:
+                    self.assertEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                 (fmt, res, rev, arg))
+
+    def test_struct_unpack_from_buffer(self):
+        for fmt, arg, big, lil, asy in self._tests:
+            for (xfmt, exp) in [('>'+fmt, big), ('!'+fmt, big), ('<'+fmt, lil),
+                                ('='+fmt, ISBIGENDIAN and big or lil)]:
+                res = struct.pack(xfmt, arg)
+                self.assertEqual(res,exp,msg="pack(%r, %r) -> %r # expected %r" %
+                                             (fmt, arg, res, exp))
+                n=struct.calcsize(xfmt)
+                self.assertEqual(n, len(res),msg="calcsize(%r) -> %d # expected %d" %
+                                                                      (xfmt, n, len(res)))
+                rev = struct.unpack_from(xfmt, buffer(res))[0]
+                if asy:
+                    self.assertNotEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                    (fmt, res, rev, exp))
+                else:
+                    self.assertEqual(arg,rev,msg="unpack(%r, %r) -> (%r,) # expected (%r,)" %
+                                                 (fmt, res, rev, arg))
+
+
+
+
+def test_main():
+    test_support.run_unittest(__name__)
+
+if __name__ == "__main__":
+    test_main()

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -286,7 +286,7 @@ class TimeoutTest(unittest.TestCase):
             u = _urlopen_with_retry(url, timeout=120)
             self.assertEqual(u.fp._sock.fp._sock.gettimeout(), 120)
 
-    FTP_HOST = "ftp://mirrors.ocf.berkeley.edu/gnu/"
+    FTP_HOST = "http://mirrors.kernel.org/gnu/"
 
     def test_ftp_basic(self):
         self.assertTrue(socket.getdefaulttimeout() is None)

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -286,7 +286,7 @@ class TimeoutTest(unittest.TestCase):
             u = _urlopen_with_retry(url, timeout=120)
             self.assertEqual(u.fp._sock.fp._sock.gettimeout(), 120)
 
-    FTP_HOST = "ftp://ftp.mirror.nl/pub/gnu/"
+    FTP_HOST = "ftp://mirrors.ocf.berkeley.edu/gnu/"
 
     def test_ftp_basic(self):
         self.assertTrue(socket.getdefaulttimeout() is None)

--- a/src/org/python/core/Py2kBuffer.java
+++ b/src/org/python/core/Py2kBuffer.java
@@ -185,28 +185,33 @@ public class Py2kBuffer extends PySequence implements BufferProtocol {
     }
 
     @Override
-    public PyString __repr__() {
+    public PyString __repr__(){
+        return buffer___repr__();
+    }
+
+    @ExposedMethod(doc=BuiltinDocs.buffer___repr___doc)
+    public PyString buffer___repr__() {
         String fmt = "<read-only buffer for %s, size %d, offset %d at 0x%s>";
         String ret = String.format(fmt, Py.idstr((PyObject)object), size, offset, Py.idstr(this));
         return new PyString(ret);
     }
 
-    @Override
-    public PyString __str__() {
+    public String toString(){
         PyBuffer buf = getBuffer();
         try {
             if (buf instanceof BaseBuffer) {
                 // In practice, it always is
-                return new PyString(buf.toString());
+                return buf.toString();
             } else {
                 // But just in case ...
                 String s = StringUtil.fromBytes(buf);
-                return new PyString(s);
+                return s ;
             }
         } finally {
             buf.release();
         }
     }
+
 
     /**
      * {@inheritDoc} A <code>buffer</code> implements this as concatenation and returns a

--- a/src/org/python/core/Py2kBuffer.java
+++ b/src/org/python/core/Py2kBuffer.java
@@ -185,13 +185,23 @@ public class Py2kBuffer extends PySequence implements BufferProtocol {
     }
 
     @Override
+    public PyString __str__(){
+        return buffer___str__();
+    }
+
+    @ExposedMethod(doc=BuiltinDocs.buffer___str___doc)
+    public PyString buffer___str__(){
+       return new PyString( toString() );
+    }
+
+    @Override
     public PyString __repr__(){
         return buffer___repr__();
     }
 
     @ExposedMethod(doc=BuiltinDocs.buffer___repr___doc)
-    public PyString buffer___repr__() {
-        String fmt = "<read-only buffer for %s, size %d, offset %d at 0x%s>";
+    public PyString buffer___repr__(){
+        String fmt = "<read-only buffer for %s, size %d, offset %d at %s>";
         String ret = String.format(fmt, Py.idstr((PyObject)object), size, offset, Py.idstr(this));
         return new PyString(ret);
     }

--- a/src/org/python/core/PyByteArray.java
+++ b/src/org/python/core/PyByteArray.java
@@ -1996,12 +1996,17 @@ public class PyByteArray extends BaseBytes implements BufferProtocol {
      */
     @Override
     public String toString() {
-        return bytearray_repr();
+        return this.asString();
+    }
+
+    @Override
+    public PyString __repr__(){
+       return bytearray___repr__();
     }
 
     @ExposedMethod(names = {"__repr__"}, doc = BuiltinDocs.bytearray___repr___doc)
-    final synchronized String bytearray_repr() {
-        return basebytes_repr("bytearray(b", ")");
+    final synchronized PyString bytearray___repr__() {
+        return new PyString(basebytes_repr("bytearray(b", ")"));
     }
 
     /**

--- a/src/org/python/modules/struct.java
+++ b/src/org/python/modules/struct.java
@@ -21,6 +21,8 @@ import org.python.core.PyTuple;
 import java.math.BigInteger;
 import org.python.core.ClassDictInit;
 import org.python.core.PyArray;
+import org.python.core.PyByteArray;
+import org.python.core.Py2kBuffer;
 
 /**
  * This module performs conversions between Python values and C
@@ -1097,6 +1099,31 @@ public class struct implements ClassDictInit {
          return unpack(f, size, format, new ByteStream(string));
     }
     
+    public static PyTuple unpack(String format, Py2kBuffer buffer){
+        return unpack(format, buffer.toString());
+    }
+
+    public static PyTuple unpack(String format, PyByteArray bytearray) {
+        /* bytearray is added in 2.7.7 */
+        return unpack(format, bytearray.toString());
+    }
+
+    public static PyTuple unpack_from(String format, Py2kBuffer buffer) {
+        return unpack_from(format, buffer.toString(), 0);
+    }
+
+    public static PyTuple unpack_from(String format, PyByteArray bytearray) {
+        return unpack_from(format, bytearray.toString(), 0);
+    }
+
+    public static PyTuple unpack_from(String format, Py2kBuffer buffer, int offset) {
+        return unpack_from(format, buffer.toString(), offset);
+    }
+
+    public static PyTuple unpack_from(String format, PyByteArray bytearray, int offset) {
+        return unpack_from(format, bytearray.toString(), offset);
+    }
+
     public static PyTuple unpack_from(String format, String string) {
         return unpack_from(format, string, 0);   
     }


### PR DESCRIPTION
cstruct unpack in py2.7 allows unpack from <type buffer> and in 2.7.6 it adds support to unpack from bytearray. These features are used in msgpack/pip and likely other python modules.

This patch adds support for to unpack from the additional types and adds test cases based on tests/test_struct.py which is not run by default.