### PR TITLE
This allows java String not already cast as a PyType to return an 8 bit

### DIFF
--- a/src/org/python/core/PyJavaType.java
+++ b/src/org/python/core/PyJavaType.java
@@ -977,13 +977,33 @@ public class PyJavaType extends PyType {
                 return Py.newInteger(self.getJavaProxy().hashCode());
             }
         });
+
+        addMethod(new PyBuiltinMethodNarrow("__str__") {
+
+            @Override
+            public PyObject __call__() {
+                /*
+                 * java.lang.Object.toString returns Unicode. Translate to PyString if 
+                 * self is java.lang.String and 8 bit clean.
+                 */
+                if (self.getJavaProxy().getClass() == java.lang.String.class) {
+                    String toString = self.getJavaProxy().toString();
+                    try {
+                        return toString == null ? Py.EmptyString : new PyString(toString);
+                    } catch (IllegalArgumentException e) {
+                        return toString == null ? Py.EmptyUnicode : Py.newUnicode(toString);
+                    }
+                } else
+                    return self.__repr__();
+            }
+        });
         addMethod(new PyBuiltinMethodNarrow("__repr__") {
 
             @Override
             public PyObject __call__() {
                 /*
                  * java.lang.Object.toString returns Unicode: preserve as a PyUnicode, then let the
-                 * repr() built-in decide how to handle it. (Also applies to __str__.)
+                 * repr() built-in decide how to handle it.
                  */
                 String toString = self.getJavaProxy().toString();
                 return toString == null ? Py.EmptyUnicode : Py.newUnicode(toString);


### PR DESCRIPTION
clean PyString when possible instead of holding it to the higher bar of
7 bit clean by passing a PyUnicode to the upstream builtin.str.

The 8 bit permissive behavior is restricted to __str__ called on
java.lang.String object specifically, and reflects both the expected
return value from str and the ambiguity between byte values and string
in py2.7.

This seemed like a sensible change but was split out of the str / repr
recursion patch set as it is a behavior change not directly needed to
achieve the goals of the other patch set.